### PR TITLE
Feature/eos 2414 multi-role endpoints and client roles

### DIFF
--- a/src/Modules/Credentials/Console/Commands/Sender/Register.php
+++ b/src/Modules/Credentials/Console/Commands/Sender/Register.php
@@ -12,6 +12,9 @@ use Ocpi\Modules\Credentials\Validators\V2_1_1\CredentialsValidator;
 use Ocpi\Modules\Versions\Actions\PartyInformationAndDetailsSynchronizeAction;
 use Ocpi\Support\Client\Client;
 
+/**
+ * @todo revisit again when we will doing as EMSP
+ */
 class Register extends Command implements PromptsForMissingInput
 {
     /**

--- a/src/Modules/Versions/Actions/PartyInformationAndDetailsSynchronizeAction.php
+++ b/src/Modules/Versions/Actions/PartyInformationAndDetailsSynchronizeAction.php
@@ -78,9 +78,13 @@ class PartyInformationAndDetailsSynchronizeAction
 
         // Set Party OCPI endpoints for version.
         Log::channel('ocpi')->info('Party '.$party->code.' - Set OCPI endpoints for version '.$party->version);
-        $party->endpoints = collect($versionDetails['endpoints'])
-            ->pluck('url', 'identifier')
-            ->toArray();
+        $endpoints = [];
+        foreach ($versionDetails['endpoints'] as $endpoint) {
+            $key = $endpoint['identifier'];
+            $innerKey = $endpoint['role'];
+            $endpoints[$key][$innerKey] = $endpoint['url'];
+        }
+        $party->endpoints = $endpoints;
         throw_if(
             ! Arr::has($party->endpoints, 'credentials'),
             new Exception('Party '.$party->code.' - Missing required `credentials` Module endpoint.')

--- a/src/Support/Client/Client.php
+++ b/src/Support/Client/Client.php
@@ -14,6 +14,7 @@ use Ocpi\Modules\Sessions\Client\Resource as SessionsResource;
 use Ocpi\Modules\Versions\Client\Resource as VersionsResource;
 use Ocpi\Support\Client\Middlewares\LogRequest;
 use Ocpi\Support\Client\Middlewares\LogResponse;
+use Ocpi\Support\Enums\InterfaceRole;
 use Ocpi\Support\Helpers\GeneratorHelper;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
@@ -24,6 +25,7 @@ class Client extends Connector
 {
     use AcceptsJson;
 
+    protected InterfaceRole $interfaceRole;
     public function __construct(
         protected readonly Party $party,
         protected readonly PartyToken $partyToken,
@@ -56,7 +58,7 @@ class Client extends Connector
         return match ($this->module) {
             'versions.information' => $this->party?->url,
             'versions.details' => $this->party?->version_url,
-            default => $this->party?->endpoints[$this->module] ?? '',
+            default => $this->party?->endpoints[$this->module][$this->interfaceRole->value] ?? '',
         };
     }
 

--- a/src/Support/Client/ReceiverClient.php
+++ b/src/Support/Client/ReceiverClient.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ocpi\Support\Client;
+
+use Ocpi\Support\Enums\InterfaceRole;
+
+class ReceiverClient extends Client
+{
+    protected InterfaceRole $interfaceRole = InterfaceRole::RECEIVER;
+}

--- a/src/Support/Client/SenderClient.php
+++ b/src/Support/Client/SenderClient.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Ocpi\Support\Client;
+
+use Ocpi\Support\Enums\InterfaceRole;
+
+class SenderClient extends Client
+{
+    protected InterfaceRole $interfaceRole = InterfaceRole::SENDER;
+}


### PR DESCRIPTION
- added SenderClient when we want to use the endpoint as a SENDER.
- added ReceiverClient when we want to use the endpoint as a RECEIVER.

new endpoint structure
```
{
  "credentials": {
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/credentials"
  },
  "locations": {
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/receiver/locations",
    "SENDER": "https://client-url.com/ocpi/2.2.1/sender/locations"
  },
  "tokens": {
    "SENDER": "https://client-url.com/ocpi/2.2.1/sender/tokens",
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/receiver/tokens"
  },
  "tariffs": {
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/receiver/tariffs",
    "SENDER": "https://client-url.com/ocpi/2.2.1/sender/tariffs"
  },
  "sessions": {
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/receiver/sessions",
    "SENDER": "https://client-url.com/ocpi/2.2.1/sender/sessions"
  },
  "cdrs": {
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/receiver/cdrs",
    "SENDER": "https://client-url.com/ocpi/2.2.1/sender/cdrs"
  },
  "commands": {
    "SENDER": "https://client-url.com/ocpi/2.2.1/sender/commands",
    "RECEIVER": "https://client-url.com/ocpi/2.2.1/receiver/commands"
  }
}
